### PR TITLE
CPU & GPU power and fan speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FPS Overlay - Lightweight Game Performance Monitor
+# FPS Overlay - Lightweight Game Performance Monitor - Anti-cheat safe
 
 A lightweight, no-bloat FPS overlay for Windows. Just stats on your screen while gaming — nothing else.
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ A lightweight, no-bloat FPS overlay for Windows. Just stats on your screen while
 ## Features
 
 - **FPS** — Real in-game framerate via Windows **ETW** (DirectX 9–12, OpenGL, Vulkan)
-- **CPU** — Usage, temperature, and optional **CPU clock (MHz)** with a minimal sparkline; pick the LHWM clock sensor in settings
-- **GPU** — Usage and temperature (NVIDIA, AMD, Intel via **LibreHardwareMonitor**)
+- **CPU** — Usage, temperature, optional **power draw (W)**, optional **fan speed (RPM)**, and optional **clock (MHz)** with a minimal sparkline; pick the LHWM clock sensor in settings
+- **GPU** — Usage, temperature, optional **power draw (W)**, and optional **fan speed (RPM)** (NVIDIA, AMD, Intel via **LibreHardwareMonitor**)
 - **GPU core clock** — Optional **core frequency (MHz)** with a minimal sparkline; pick the clock sensor for the **selected GPU**
 - **Multi-GPU** — Detect all discrete GPUs and choose which one to monitor
 - **VRAM** — Memory usage (percent and used / total GB)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A lightweight, no-bloat FPS overlay for Windows. Just stats on your screen while
 
 ![Size](https://img.shields.io/badge/size-~9MB-brightgreen) ![Platform](https://img.shields.io/badge/platform-Windows-blue) ![License](https://img.shields.io/badge/license-GNU%20GPLv3-green) ![Status](https://img.shields.io/badge/status-beta-orange)
 
+> ⭐ If you like FPS Overlay, please leave a star. It supports the project and keeps it growing. Thank you! ⭐
+
+---
+
 > [!WARNING]
 > **⚠️ Beta Software:** This project is currently in beta and under active development. Features, UI, and behavior are subject to change. Feedback and bug reports are welcome!
 
@@ -24,9 +28,11 @@ A lightweight, no-bloat FPS overlay for Windows. Just stats on your screen while
 
 > [!CAUTION]
 > #### Fullscreen display modes are not supported\*
-> Games require **Borderless**/**Borderless Windowed** mode to be enabled via in-game display settings in order for the fps overlay to show above the game window.
+> Games require **Borderless**/**Borderless Windowed**/**Borderless Fullscreen** mode to be enabled via in-game display settings in order for the FPS Overlay to show above the game window.
 >
-> FPS Overlay will only work in windowed fullscreen mode and windowed borderless fullscreen mode, but will not work in true fullscreen mode. True fullscreen mode on desktop means that other computer applications cannot be displayed over the application that’s in true fullscreen mode.
+> FPS Overlay will only work in **windowed fullscreen mode** and **windowed borderless fullscreen mode**, but will not work in true **fullscreen mode** or **exclusive fullscreen mode**. True **fullscreen mode** and **exclusive fullscreen mode** on desktop means that other computer applications cannot be displayed over the application that’s in **fullscreen mode** and **exclusive fullscreen mode**.
+
+---
 
 ## Features
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -147,6 +147,10 @@ struct OverlayConfig {
     float customY = -1.0f;
     int  selectedGpu = 0;     // selected GPU index (0 = first GPU)
     int  overlayScale = 100;  // 50..200 % UI scale for all layouts
+    bool showCpuPower = false;
+    bool showGpuPower = false;
+    bool showCpuFan = false;
+    bool showGpuFan = false;
     bool showCpuFreq = false;
     bool showGpuCoreFreq = false;
     char cpuFreqPath[FREQ_PATH_MAX] = "";
@@ -165,6 +169,8 @@ struct GpuInfo {
     std::string vramUsedPath;  // LHWM sensor path for VRAM used
     std::string vramTotalPath; // LHWM sensor path for VRAM total
     int         vramTotalPri = -1; // higher = better match (see VramTotalSensorPriority)
+    std::string powerPath;         // LHWM sensor path for GPU power (Watts)
+    std::string fanPath;           // LHWM sensor path for GPU fan speed (RPM)
     std::vector<std::pair<std::string, std::string>> coreClockOpts; // display name, path
 };
 static GpuInfo g_gpuList[MAX_GPUS];
@@ -328,6 +334,10 @@ static void LoadConfig(OverlayConfig& cfg)
     cfg.showRAM       = ReadIniInt("Display", "showRAM", 1) != 0;
     cfg.showProcessName = ReadIniInt("Display", "showProcessName", 1) != 0;
 
+    cfg.showCpuPower    = ReadIniInt("Display", "showCpuPower", 0) != 0;
+    cfg.showGpuPower    = ReadIniInt("Display", "showGpuPower", 0) != 0;
+    cfg.showCpuFan      = ReadIniInt("Display", "showCpuFan", 0) != 0;
+    cfg.showGpuFan      = ReadIniInt("Display", "showGpuFan", 0) != 0;
     cfg.showCpuFreq     = ReadIniInt("Frequency", "showCpuFreq", 0) != 0;
     cfg.showGpuCoreFreq = ReadIniInt("Frequency", "showGpuCoreFreq", 0) != 0;
     ReadIniStr("Frequency", "cpuFreqPath", cfg.cpuFreqPath, sizeof(cfg.cpuFreqPath));
@@ -448,6 +458,10 @@ static void SaveConfig(const OverlayConfig& cfg)
     WriteIniInt("Display", "showVRAM", cfg.showVRAM ? 1 : 0);
     WriteIniInt("Display", "showRAM", cfg.showRAM ? 1 : 0);
     WriteIniInt("Display", "showProcessName", cfg.showProcessName ? 1 : 0);
+    WriteIniInt("Display", "showCpuPower", cfg.showCpuPower ? 1 : 0);
+    WriteIniInt("Display", "showGpuPower", cfg.showGpuPower ? 1 : 0);
+    WriteIniInt("Display", "showCpuFan", cfg.showCpuFan ? 1 : 0);
+    WriteIniInt("Display", "showGpuFan", cfg.showGpuFan ? 1 : 0);
 
     WriteIniInt("Frequency", "showCpuFreq", cfg.showCpuFreq ? 1 : 0);
     WriteIniInt("Frequency", "showGpuCoreFreq", cfg.showGpuCoreFreq ? 1 : 0);
@@ -616,7 +630,15 @@ static std::string g_lhwmGpuTempPath;      // e.g., "/gpu-nvidia/0/temperature/0
 static std::string g_lhwmGpuLoadPath;      // e.g., "/gpu-nvidia/0/load/0"
 static std::string g_lhwmGpuVramUsedPath;  // VRAM used
 static std::string g_lhwmGpuVramTotalPath; // VRAM total
+static std::string g_lhwmCpuPowerPath;     // CPU package power sensor
+static std::string g_lhwmGpuPowerPath;     // Active GPU power sensor
+static std::string g_lhwmCpuFanPath;       // CPU fan sensor (from any hardware node)
+static std::string g_lhwmGpuFanPath;       // Active GPU fan sensor
 static float g_lhwmCpuTemp = 0.0f;         // CPU temp from LHWM (used directly)
+static float g_cpuPower = 0.0f;            // CPU power draw in Watts
+static float g_gpuPower = 0.0f;            // GPU power draw in Watts
+static float g_cpuFanRpm = 0.0f;           // CPU fan speed in RPM
+static float g_gpuFanRpm = 0.0f;           // GPU fan speed in RPM
 
 // CPU / GPU core clock options and live values (MHz) + sparkline history
 static std::vector<std::pair<std::string, std::string>> g_cpuClockOpts;
@@ -1882,6 +1904,8 @@ static bool InitLHWM()
                     g_gpuList[gpuIndex].vramUsedPath.clear();
                     g_gpuList[gpuIndex].vramTotalPath.clear();
                     g_gpuList[gpuIndex].vramTotalPri = -1;
+                    g_gpuList[gpuIndex].powerPath.clear();
+                    g_gpuList[gpuIndex].fanPath.clear();
                     g_gpuCount++;
                 }
             }
@@ -1897,6 +1921,24 @@ static bool InitLHWM()
                                   sensorPath.find("/gpu-amd/") != std::string::npos ||
                                   sensorPath.find("/gpu-intel/") != std::string::npos);
                 
+                // CPU fan — search all non-GPU hardware for a fan sensor named "CPU"
+                if (sensorType == "Fan" && !isGpuPath && g_lhwmCpuFanPath.empty()) {
+                    std::string nl;
+                    nl.reserve(sensorName.size());
+                    for (char c : sensorName) nl += (char)tolower((unsigned char)c);
+                    if (nl.find("cpu") != std::string::npos)
+                        g_lhwmCpuFanPath = sensorPath;
+                }
+
+                // CPU power sensors
+                if ((isCpuHardware || isCpuPath) && !isGpuPath && sensorType == "Power") {
+                    if (sensorName.find("Package") != std::string::npos) {
+                        g_lhwmCpuPowerPath = sensorPath;
+                    } else if (g_lhwmCpuPowerPath.empty()) {
+                        g_lhwmCpuPowerPath = sensorPath;
+                    }
+                }
+
                 // CPU temperature sensors
                 if ((isCpuHardware || isCpuPath) && sensorType == "Temperature") {
                     // Priority order for CPU temp (matching Task Manager):
@@ -1962,6 +2004,19 @@ static bool InitLHWM()
                         if (!dup)
                             g_gpuList[gpuIndex].coreClockOpts.push_back({ sensorName, sensorPath });
                     }
+                    else if (sensorType == "Power") {
+                        // Prefer Package power; fall back to first available power sensor
+                        if (sensorName.find("Package") != std::string::npos ||
+                            g_gpuList[gpuIndex].powerPath.empty()) {
+                            g_gpuList[gpuIndex].powerPath = sensorPath;
+                        }
+                    }
+                    else if (sensorType == "Fan") {
+                        // Prefer "GPU Fan" (summary); fall back to first fan sensor found
+                        if (sensorName == "GPU Fan" || g_gpuList[gpuIndex].fanPath.empty()) {
+                            g_gpuList[gpuIndex].fanPath = sensorPath;
+                        }
+                    }
                 }
 
                 if (sensorType == "Clock") {
@@ -1993,6 +2048,8 @@ static bool InitLHWM()
             g_lhwmGpuLoadPath = g_gpuList[idx].loadPath;
             g_lhwmGpuVramUsedPath = g_gpuList[idx].vramUsedPath;
             g_lhwmGpuVramTotalPath = g_gpuList[idx].vramTotalPath;
+            g_lhwmGpuPowerPath = g_gpuList[idx].powerPath;
+            g_lhwmGpuFanPath   = g_gpuList[idx].fanPath;
             snprintf(g_gpuName, sizeof(g_gpuName), "%s", g_gpuList[idx].name);
         }
 
@@ -2043,6 +2100,18 @@ static void PollLHWMStats()
         if (!g_lhwmGpuVramTotalPath.empty()) {
             g_vramTotal = LHWM::GetSensorValue(g_lhwmGpuVramTotalPath) / 1024.0f;
         }
+        if (!g_lhwmCpuPowerPath.empty()) {
+            g_cpuPower = LHWM::GetSensorValue(g_lhwmCpuPowerPath);
+        }
+        if (!g_lhwmGpuPowerPath.empty()) {
+            g_gpuPower = LHWM::GetSensorValue(g_lhwmGpuPowerPath);
+        }
+        if (!g_lhwmCpuFanPath.empty()) {
+            g_cpuFanRpm = LHWM::GetSensorValue(g_lhwmCpuFanPath);
+        }
+        if (!g_lhwmGpuFanPath.empty()) {
+            g_gpuFanRpm = LHWM::GetSensorValue(g_lhwmGpuFanPath);
+        }
     }
     catch (...) {
         // Silently ignore polling errors
@@ -2061,7 +2130,9 @@ static void SelectGpu(int index)
     g_lhwmGpuLoadPath = g_gpuList[index].loadPath;
     g_lhwmGpuVramUsedPath = g_gpuList[index].vramUsedPath;
     g_lhwmGpuVramTotalPath = g_gpuList[index].vramTotalPath;
-    
+    g_lhwmGpuPowerPath = g_gpuList[index].powerPath;
+    g_lhwmGpuFanPath   = g_gpuList[index].fanPath;
+
     snprintf(g_gpuName, sizeof(g_gpuName), "%s", g_gpuList[index].name);
 
     ValidateFrequencyPaths();
@@ -2741,11 +2812,51 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE, LPSTR, int)
             }
             ImGui::Checkbox("  CPU Usage", &g_Config.showCpuUsage);
             ImGui::Checkbox("  CPU Temp", &g_Config.showCpuTemp);
+            ImGui::Checkbox("  CPU Power (W)", &g_Config.showCpuPower);
+            {
+                const bool lhwmBusy = !g_lhwmInitFinished.load(std::memory_order_acquire);
+                const bool lhwmBad = !g_lhwmAvailable || g_lhwmCpuPowerPath.empty();
+                if (lhwmBusy || lhwmBad) {
+                    ImGui::SameLine();
+                    ImGui::TextColored(lhwmBusy ? ImVec4(.55f,.55f,.58f,1) : ImVec4(.9f,.4f,.2f,1),
+                                       lhwmBusy ? "(loading…)" : "(unavailable)");
+                }
+            }
+            ImGui::Checkbox("  CPU Fan (RPM)", &g_Config.showCpuFan);
+            {
+                const bool lhwmBusy = !g_lhwmInitFinished.load(std::memory_order_acquire);
+                const bool lhwmBad = !g_lhwmAvailable || g_lhwmCpuFanPath.empty();
+                if (lhwmBusy || lhwmBad) {
+                    ImGui::SameLine();
+                    ImGui::TextColored(lhwmBusy ? ImVec4(.55f,.55f,.58f,1) : ImVec4(.9f,.4f,.2f,1),
+                                       lhwmBusy ? "(loading…)" : "(unavailable)");
+                }
+            }
             ImGui::Checkbox("  GPU Usage", &g_Config.showGpuUsage);
             ImGui::Checkbox("  GPU Temp", &g_Config.showGpuTemp);
             {
                 const bool lhwmBusy = !g_lhwmInitFinished.load(std::memory_order_acquire);
                 const bool lhwmBad = !g_lhwmAvailable || g_gpuCount == 0;
+                if (lhwmBusy || lhwmBad) {
+                    ImGui::SameLine();
+                    ImGui::TextColored(lhwmBusy ? ImVec4(.55f,.55f,.58f,1) : ImVec4(.9f,.4f,.2f,1),
+                                       lhwmBusy ? "(loading…)" : "(unavailable)");
+                }
+            }
+            ImGui::Checkbox("  GPU Power (W)", &g_Config.showGpuPower);
+            {
+                const bool lhwmBusy = !g_lhwmInitFinished.load(std::memory_order_acquire);
+                const bool lhwmBad = !g_lhwmAvailable || g_gpuCount == 0 || g_lhwmGpuPowerPath.empty();
+                if (lhwmBusy || lhwmBad) {
+                    ImGui::SameLine();
+                    ImGui::TextColored(lhwmBusy ? ImVec4(.55f,.55f,.58f,1) : ImVec4(.9f,.4f,.2f,1),
+                                       lhwmBusy ? "(loading…)" : "(unavailable)");
+                }
+            }
+            ImGui::Checkbox("  GPU Fan (RPM)", &g_Config.showGpuFan);
+            {
+                const bool lhwmBusy = !g_lhwmInitFinished.load(std::memory_order_acquire);
+                const bool lhwmBad = !g_lhwmAvailable || g_gpuCount == 0 || g_lhwmGpuFanPath.empty();
                 if (lhwmBusy || lhwmBad) {
                     ImGui::SameLine();
                     ImGui::TextColored(lhwmBusy ? ImVec4(.55f,.55f,.58f,1) : ImVec4(.9f,.4f,.2f,1),
@@ -3356,8 +3467,10 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE, LPSTR, int)
                     needSep = true;
                 }
 
-                const bool wantCpuHzSt = g_Config.showCpuFreq && g_Config.cpuFreqPath[0] && g_lhwmAvailable;
-                if (g_Config.showCpuUsage || g_Config.showCpuTemp || wantCpuHzSt) {
+                const bool wantCpuHzSt  = g_Config.showCpuFreq && g_Config.cpuFreqPath[0] && g_lhwmAvailable;
+                const bool wantCpuPwrSt = g_Config.showCpuPower && !g_lhwmCpuPowerPath.empty() && g_lhwmAvailable;
+                const bool wantCpuFanSt = g_Config.showCpuFan && !g_lhwmCpuFanPath.empty() && g_lhwmAvailable;
+                if (g_Config.showCpuUsage || g_Config.showCpuTemp || wantCpuHzSt || wantCpuPwrSt || wantCpuFanSt) {
                     if (needSep) {
                         ImGui::SameLine(0, hs);
                         ImGui::TextColored(sepC, "|");
@@ -3394,11 +3507,29 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE, LPSTR, int)
                         InlineFreqSparkMHz("##st_cpu", g_cpuSpark, g_cpuSparkN, g_cpuClockMHz,
                                            ImVec2(38.f * ss, 11.f * ss), 5.f * ss, ImVec4(.75f, .75f, .78f, 1.f));
                     }
+                    if (wantCpuPwrSt && g_cpuPower > 0.f) {
+                        if (anyCpuSteam) {
+                            ImGui::SameLine(0, hsTight);
+                            ImGui::TextColored(sepC, "|");
+                            ImGui::SameLine(0, hsTight);
+                        }
+                        ImGui::TextColored(ImVec4(.85f, .78f, .55f, 1), "%.0fW", g_cpuPower);
+                    }
+                    if (wantCpuFanSt) {
+                        if (anyCpuSteam) {
+                            ImGui::SameLine(0, hsTight);
+                            ImGui::TextColored(sepC, "|");
+                            ImGui::SameLine(0, hsTight);
+                        }
+                        ImGui::TextColored(ImVec4(.60f, .80f, .90f, 1), "%.0frpm", g_cpuFanRpm);
+                    }
                     needSep = true;
                 }
 
-                const bool wantGpuHzSt = g_Config.showGpuCoreFreq && g_Config.gpuCoreFreqPath[0] && g_lhwmAvailable;
-                if (g_Config.showGpuUsage || g_Config.showGpuTemp || wantGpuHzSt) {
+                const bool wantGpuHzSt  = g_Config.showGpuCoreFreq && g_Config.gpuCoreFreqPath[0] && g_lhwmAvailable;
+                const bool wantGpuPwrSt = g_Config.showGpuPower && !g_lhwmGpuPowerPath.empty() && g_lhwmAvailable;
+                const bool wantGpuFanSt = g_Config.showGpuFan && !g_lhwmGpuFanPath.empty() && g_lhwmAvailable;
+                if (g_Config.showGpuUsage || g_Config.showGpuTemp || wantGpuHzSt || wantGpuPwrSt || wantGpuFanSt) {
                     if (needSep) {
                         ImGui::SameLine(0, hs);
                         ImGui::TextColored(sepC, "|");
@@ -3438,6 +3569,22 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE, LPSTR, int)
                             }
                             InlineFreqSparkMHz("##st_gpu", g_gpuSpark, g_gpuSparkN, g_gpuCoreClockMHz,
                                                ImVec2(38.f * ss, 11.f * ss), 5.f * ss, ImVec4(.75f, .75f, .78f, 1.f));
+                        }
+                        if (wantGpuPwrSt && g_gpuPower > 0.f) {
+                            if (anyGpuSteam) {
+                                ImGui::SameLine(0, hsTight);
+                                ImGui::TextColored(sepC, "|");
+                                ImGui::SameLine(0, hsTight);
+                            }
+                            ImGui::TextColored(ImVec4(.85f, .78f, .55f, 1), "%.0fW", g_gpuPower);
+                        }
+                        if (wantGpuFanSt) {
+                            if (anyGpuSteam) {
+                                ImGui::SameLine(0, hsTight);
+                                ImGui::TextColored(sepC, "|");
+                                ImGui::SameLine(0, hsTight);
+                            }
+                            ImGui::TextColored(ImVec4(.60f, .80f, .90f, 1), "%.0frpm", g_gpuFanRpm);
                         }
                     } else {
                         ImGui::TextColored(ImVec4(.50f, .50f, .55f, 1.f), "N/A");
@@ -3496,12 +3643,16 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE, LPSTR, int)
                     }
                     needSep = true;
                 }
-                
+
                 // CPU
                 {
                     const bool wantCpuHzHz =
                         g_Config.showCpuFreq && g_Config.cpuFreqPath[0] && g_lhwmAvailable;
-                    if (g_Config.showCpuUsage || g_Config.showCpuTemp || wantCpuHzHz) {
+                    const bool wantCpuPwrHz =
+                        g_Config.showCpuPower && !g_lhwmCpuPowerPath.empty() && g_lhwmAvailable;
+                    const bool wantCpuFanHz =
+                        g_Config.showCpuFan && !g_lhwmCpuFanPath.empty() && g_lhwmAvailable;
+                    if (g_Config.showCpuUsage || g_Config.showCpuTemp || wantCpuHzHz || wantCpuPwrHz || wantCpuFanHz) {
                         if (needSep) {
                             ImGui::SameLine();
                             ImGui::TextColored(ImVec4(.35f, .35f, .40f, 1), " | ");
@@ -3510,7 +3661,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE, LPSTR, int)
                         const bool hasCpuTempVal = g_cpuTempAvailable && g_cpuTemp > 0;
                         if (g_Config.showCpuUsage)
                             ImGui::TextColored(ColorByLoad(cpuUsage), "CPU %.0f%%", cpuUsage);
-                        else if (g_Config.showCpuTemp || wantCpuHzHz)
+                        else if (g_Config.showCpuTemp || wantCpuHzHz || wantCpuPwrHz || wantCpuFanHz)
                             ImGui::TextColored(ImVec4(.78f, .78f, .82f, 1), "CPU");
 
                         if (g_Config.showCpuTemp && hasCpuTempVal) {
@@ -3535,6 +3686,14 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE, LPSTR, int)
                                                ImVec2(52.f * ovSc, 12.f * ovSc), 6.f * ovSc,
                                                ImVec4(.62f, .62f, .68f, 1.f));
                         }
+                        if (wantCpuPwrHz && g_cpuPower > 0.f) {
+                            ImGui::SameLine(0, 2);
+                            ImGui::TextColored(ImVec4(.85f, .78f, .55f, 1), " %.0fW", g_cpuPower);
+                        }
+                        if (wantCpuFanHz) {
+                            ImGui::SameLine(0, 2);
+                            ImGui::TextColored(ImVec4(.60f, .80f, .90f, 1), " %.0frpm", g_cpuFanRpm);
+                        }
                         needSep = true;
                     }
                 }
@@ -3543,7 +3702,11 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE, LPSTR, int)
                 {
                     const bool wantGpuHzHz =
                         g_Config.showGpuCoreFreq && g_Config.gpuCoreFreqPath[0] && g_lhwmAvailable;
-                    if (g_Config.showGpuUsage || g_Config.showGpuTemp || wantGpuHzHz) {
+                    const bool wantGpuPwrHz =
+                        g_Config.showGpuPower && !g_lhwmGpuPowerPath.empty() && g_lhwmAvailable;
+                    const bool wantGpuFanHz =
+                        g_Config.showGpuFan && !g_lhwmGpuFanPath.empty() && g_lhwmAvailable;
+                    if (g_Config.showGpuUsage || g_Config.showGpuTemp || wantGpuHzHz || wantGpuPwrHz || wantGpuFanHz) {
                         if (needSep) {
                             ImGui::SameLine();
                             ImGui::TextColored(ImVec4(.35f, .35f, .40f, 1), " | ");
@@ -3557,7 +3720,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE, LPSTR, int)
                         if (hasGpuData) {
                             if (g_Config.showGpuUsage)
                                 ImGui::TextColored(ColorByLoad(dispGpuLoad), "GPU %.0f%%", dispGpuLoad);
-                            else if (g_Config.showGpuTemp || wantGpuHzHz)
+                            else if (g_Config.showGpuTemp || wantGpuHzHz || wantGpuPwrHz || wantGpuFanHz)
                                 ImGui::TextColored(ImVec4(.78f, .78f, .82f, 1), "GPU");
 
                             if (g_Config.showGpuTemp && dispGpuTemp > 0) {
@@ -3582,13 +3745,21 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE, LPSTR, int)
                                                    ImVec2(52.f * ovSc, 12.f * ovSc), 6.f * ovSc,
                                                    ImVec4(.62f, .62f, .68f, 1.f));
                             }
+                            if (wantGpuPwrHz && g_gpuPower > 0.f) {
+                                ImGui::SameLine(0, 2);
+                                ImGui::TextColored(ImVec4(.85f, .78f, .55f, 1), " %.0fW", g_gpuPower);
+                            }
+                            if (wantGpuFanHz) {
+                                ImGui::SameLine(0, 2);
+                                ImGui::TextColored(ImVec4(.60f, .80f, .90f, 1), " %.0frpm", g_gpuFanRpm);
+                            }
                         } else {
                             ImGui::TextColored(ImVec4(.50f, .50f, .55f, 1), "GPU N/A");
                         }
                         needSep = true;
                     }
                 }
-                
+
                 // VRAM
                 if (g_Config.showVRAM) {
                     float dispVramUsed = g_vramUsed;
@@ -3652,7 +3823,11 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE, LPSTR, int)
                 {
                     const bool wantCpuHzV =
                         g_Config.showCpuFreq && g_Config.cpuFreqPath[0] && g_lhwmAvailable;
-                    if (g_Config.showCpuUsage || g_Config.showCpuTemp || wantCpuHzV) {
+                    const bool wantCpuPwrV =
+                        g_Config.showCpuPower && !g_lhwmCpuPowerPath.empty() && g_lhwmAvailable;
+                    const bool wantCpuFanV =
+                        g_Config.showCpuFan && !g_lhwmCpuFanPath.empty() && g_lhwmAvailable;
+                    if (g_Config.showCpuUsage || g_Config.showCpuTemp || wantCpuHzV || wantCpuPwrV || wantCpuFanV) {
                         if (needSep) {
                             ImGui::Spacing();
                             ImGui::Separator();
@@ -3675,6 +3850,10 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE, LPSTR, int)
                             ImGui::TextColored(ImVec4(.50f, .50f, .55f, 1), "CPU  ---");
                         }
 
+                        if (wantCpuPwrV && g_cpuPower > 0.f)
+                            ImGui::TextColored(ImVec4(.85f, .78f, .55f, 1), "PWR  %.0f W", g_cpuPower);
+                        if (wantCpuFanV)
+                            ImGui::TextColored(ImVec4(.60f, .80f, .90f, 1), "FAN  %.0f RPM", g_cpuFanRpm);
                         ImGui::SetWindowFontScale(0.82f * ovSc);
                         ImGui::TextColored(ImVec4(.42f, .42f, .48f, 1), "  %s", g_cpuName);
                         ImGui::SetWindowFontScale(ovSc);
@@ -3693,8 +3872,13 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE, LPSTR, int)
                 {
                     const bool wantGpuHzV =
                         g_Config.showGpuCoreFreq && g_Config.gpuCoreFreqPath[0] && g_lhwmAvailable;
+                    const bool wantGpuPwrV =
+                        g_Config.showGpuPower && !g_lhwmGpuPowerPath.empty() && g_lhwmAvailable;
+                    const bool wantGpuFanV =
+                        g_Config.showGpuFan && !g_lhwmGpuFanPath.empty() && g_lhwmAvailable;
                     const bool gpuVertBlock = g_Config.showGpuUsage || g_Config.showGpuTemp || wantGpuHzV ||
-                                              (g_Config.showVRAM && g_lhwmAvailable && g_gpuCount > 0);
+                                              (g_Config.showVRAM && g_lhwmAvailable && g_gpuCount > 0) ||
+                                              wantGpuPwrV || wantGpuFanV;
                     if (gpuVertBlock) {
                         if (needSep) {
                             ImGui::Spacing();
@@ -3732,6 +3916,10 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE, LPSTR, int)
                                 ImGui::TextColored(ImVec4(.70f, .70f, .75f, 1), " %.1f / %.0f GB", dispVramUsed,
                                                    dispVramTotal);
                             }
+                            if (wantGpuPwrV && g_gpuPower > 0.f)
+                                ImGui::TextColored(ImVec4(.85f, .78f, .55f, 1), "PWR  %.0f W", g_gpuPower);
+                            if (wantGpuFanV)
+                                ImGui::TextColored(ImVec4(.60f, .80f, .90f, 1), "FAN  %.0f RPM", g_gpuFanRpm);
                         } else {
                             ImGui::TextColored(ImVec4(.50f, .50f, .55f, 1), "GPU  N/A");
                         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,6 +166,7 @@ struct GpuInfo {
     char name[256];
     std::string tempPath;      // LHWM sensor path for temperature
     std::string loadPath;      // LHWM sensor path for GPU load
+    int         loadPathPri  = -1; // higher = better match: 2=exact "GPU Core", 1=contains "GPU Core", 0=fallback
     std::string vramUsedPath;  // LHWM sensor path for VRAM used
     std::string vramTotalPath; // LHWM sensor path for VRAM total
     int         vramTotalPri = -1; // higher = better match (see VramTotalSensorPriority)
@@ -1975,10 +1976,15 @@ static bool InitLHWM()
                         }
                     }
                     else if (sensorType == "Load") {
-                        if (sensorName.find("Core") != std::string::npos || 
-                            sensorName.find("GPU") != std::string::npos ||
-                            g_gpuList[gpuIndex].loadPath.empty()) {
-                            g_gpuList[gpuIndex].loadPath = sensorPath;
+                        // Priority: 2=exact "GPU Core", 1=contains "GPU Core", 0=any other (first fallback)
+                        // This prevents "GPU Memory Controller", "GPU Bus", "GPU Video Engine", etc.
+                        // from overwriting the correct 3D-engine load sensor.
+                        int pri = (sensorName == "GPU Core") ? 2
+                                : (sensorName.find("GPU Core") != std::string::npos) ? 1
+                                : 0;
+                        if (pri > g_gpuList[gpuIndex].loadPathPri) {
+                            g_gpuList[gpuIndex].loadPath    = sensorPath;
+                            g_gpuList[gpuIndex].loadPathPri = pri;
                         }
                     }
                     else if (sensorType == "SmallData" || sensorType == "Data") {


### PR DESCRIPTION
Hi! First of all — thank you for building this tool. It's exactly what I was looking for: lightweight, no bloat and open source. Really appreciate the work you've put into it.

I added a couple of optional stats that I personally find useful while gaming. Feel free to include them if you think they fit the project, or ignore this PR entirely — no pressure at all.

What's added

CPU & GPU power draw (Watts)
- Reads the Power sensor via LibreHardwareMonitor (prefers the Package sensor when multiple are available)
- Displayed as e.g. 125W / 220W

CPU & GPU fan speed (RPM)
- Reads the Fan sensor via LHWM
- CPU fan is detected by searching all hardware nodes for a fan sensor whose name contains "cpu" (since CPU fans are typically reported under the motherboard/SuperIO chip node, not the CPU hardware node)
- GPU fan prefers the GPU Fan summary sensor (useful on multi-fan cards like NVIDIA)
- Shows 0 rpm when the sensor is available but reports zero (e.g. fan stopped at idle)

Implementation details

- Both features are opt-in — off by default, toggleable in the Settings UI with LHWM availability indicators
- Settings are persisted to config.ini via the existing INI system
- Displayed in all three layouts (Vertical, Horizontal Compact, Steam-style)
- Sensor paths are wired through the existing GpuInfo struct and SelectGpu() so multi-GPU switching works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional CPU power draw (watts) and fan speed (RPM) display in overlay
  * Added optional GPU power draw (watts) and fan speed (RPM) display for NVIDIA/AMD/Intel
  * Added settings toggles to enable/disable power and fan metrics for CPU and GPU

* **Documentation**
  * Updated feature descriptions for CPU and GPU stats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->