### PR TITLE
Fix: GPU load % reads wrong LHWM sensor, causing inflated values;

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FPS Overlay - Lightweight Game Performance Monitor
+# FPS Overlay - Lightweight Game Performance Monitor - Anti-cheat safe
 
 A lightweight, no-bloat FPS overlay for Windows. Just stats on your screen while gaming — nothing else.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A lightweight, no-bloat FPS overlay for Windows. Just stats on your screen while
 
 ![Size](https://img.shields.io/badge/size-~9MB-brightgreen) ![Platform](https://img.shields.io/badge/platform-Windows-blue) ![License](https://img.shields.io/badge/license-GNU%20GPLv3-green) ![Status](https://img.shields.io/badge/status-beta-orange)
 
+> ⭐ If you like FPS Overlay, please leave a star. It supports the project and keeps it growing. Thank you! ⭐
+
+---
+
 > [!WARNING]
 > **⚠️ Beta Software:** This project is currently in beta and under active development. Features, UI, and behavior are subject to change. Feedback and bug reports are welcome!
 
@@ -24,9 +28,11 @@ A lightweight, no-bloat FPS overlay for Windows. Just stats on your screen while
 
 > [!CAUTION]
 > #### Fullscreen display modes are not supported\*
-> Games require **Borderless**/**Borderless Windowed** mode to be enabled via in-game display settings in order for the fps overlay to show above the game window.
+> Games require **Borderless**/**Borderless Windowed**/**Borderless Fullscreen** mode to be enabled via in-game display settings in order for the FPS Overlay to show above the game window.
 >
-> FPS Overlay will only work in windowed fullscreen mode and windowed borderless fullscreen mode, but will not work in true fullscreen mode. True fullscreen mode on desktop means that other computer applications cannot be displayed over the application that’s in true fullscreen mode.
+> FPS Overlay will only work in **windowed fullscreen mode** and **windowed borderless fullscreen mode**, but will not work in true **fullscreen mode** or **exclusive fullscreen mode**. True **fullscreen mode** and **exclusive fullscreen mode** on desktop means that other computer applications cannot be displayed over the application that’s in **fullscreen mode** and **exclusive fullscreen mode**.
+
+---
 
 ## Features
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -162,6 +162,7 @@ struct GpuInfo {
     char name[256];
     std::string tempPath;      // LHWM sensor path for temperature
     std::string loadPath;      // LHWM sensor path for GPU load
+    int         loadPathPri  = -1; // higher = better match: 2=exact "GPU Core", 1=contains "GPU Core", 0=fallback
     std::string vramUsedPath;  // LHWM sensor path for VRAM used
     std::string vramTotalPath; // LHWM sensor path for VRAM total
     int         vramTotalPri = -1; // higher = better match (see VramTotalSensorPriority)
@@ -1933,10 +1934,15 @@ static bool InitLHWM()
                         }
                     }
                     else if (sensorType == "Load") {
-                        if (sensorName.find("Core") != std::string::npos || 
-                            sensorName.find("GPU") != std::string::npos ||
-                            g_gpuList[gpuIndex].loadPath.empty()) {
-                            g_gpuList[gpuIndex].loadPath = sensorPath;
+                        // Priority: 2=exact "GPU Core", 1=contains "GPU Core", 0=any other (first fallback)
+                        // This prevents "GPU Memory Controller", "GPU Bus", "GPU Video Engine", etc.
+                        // from overwriting the correct 3D-engine load sensor.
+                        int pri = (sensorName == "GPU Core") ? 2
+                                : (sensorName.find("GPU Core") != std::string::npos) ? 1
+                                : 0;
+                        if (pri > g_gpuList[gpuIndex].loadPathPri) {
+                            g_gpuList[gpuIndex].loadPath    = sensorPath;
+                            g_gpuList[gpuIndex].loadPathPri = pri;
                         }
                     }
                     else if (sensorType == "SmallData" || sensorType == "Data") {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1880,6 +1880,7 @@ static bool InitLHWM()
                     snprintf(g_gpuList[gpuIndex].name, sizeof(g_gpuList[gpuIndex].name), "%s", cleanName.c_str());
                     g_gpuList[gpuIndex].tempPath.clear();
                     g_gpuList[gpuIndex].loadPath.clear();
+                    g_gpuList[gpuIndex].loadPathPri = -1;
                     g_gpuList[gpuIndex].vramUsedPath.clear();
                     g_gpuList[gpuIndex].vramTotalPath.clear();
                     g_gpuList[gpuIndex].vramTotalPri = -1;


### PR DESCRIPTION
### Problem

GPU load was consistently inflated (≥11% at idle) compared to the NVIDIA overlay (0–2%).

**Root cause** — the sensor selection logic in `InitLHWM()` used `sensorName.find("GPU") != std::string::npos` as an overwrite condition. LibreHardwareMonitor enumerates NVIDIA Load sensors in order:

GPU Core → GPU Memory Controller → GPU Bus → GPU Video Engine → GPU Copy Engine

Every sensor contains "GPU" in its name, so each one overwrote the previous. The **last** sensor in the list always won — typically `GPU Copy Engine` or `GPU Video Engine` — both of which are permanently active due to DWM and the overlay itself, producing an artificial baseline load.

### Fix

Replaced the flat condition with a priority-based selection (identical in pattern to the existing `vramTotalPri` logic):

| Priority | Condition |
|---|---|
| 2 | `sensorName == "GPU Core"` (exact match — 3D engine) |
| 1 | `sensorName` contains `"GPU Core"` |
| 0 | any other Load sensor (first-found fallback) |

A higher-priority match can never be overwritten by a lower one. This ensures the **3D engine** sensor (`GPU Core`) is always selected when available — the same metric NVIDIA overlay reports.

### Note

A small residual difference between this overlay and NVIDIA Overlay is expected: LHWM reads **total** `GPU Core` utilization (all processes), while NVIDIA Overlay may filter to the foreground game process only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU load sensor selection with enhanced prioritization logic to ensure accurate identification of GPU Core load sensors, preventing unrelated sensors from causing incorrect monitoring readings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->